### PR TITLE
Custom Cypress base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # docker-images
 
-Various alpine based docker images used by Ecosia - https://hub.docker.com/u/ecosiadev/
+Various (mostly) alpine based docker images used by Ecosia - https://hub.docker.com/u/ecosiadev/

--- a/cypress-base/Dockerfile
+++ b/cypress-base/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:10.15.3-slim
+
+RUN apt-get update && \
+  apt-get install -y \
+    libgtk2.0-0 \
+    libnotify-dev \
+    libgconf-2-4 \
+    libnss3 \
+    libxss1 \
+    libasound2 \
+    xvfb
+
+RUN npm install -g npm@6.9.0
+RUN npm install -g yarn@1.15.2
+
+# versions of local tools
+RUN echo  " node version:    $(node -v) \n" \
+          "npm version:     $(npm -v) \n" \
+          "yarn version:    $(yarn -v) \n" \
+          "debian version:  $(cat /etc/debian_version) \n"

--- a/cypress-base/README.md
+++ b/cypress-base/README.md
@@ -1,0 +1,3 @@
+# Ecosia Cypress Base
+
+This image is almost identical to [`cypress/base:10.15.3`](https://github.com/cypress-io/cypress-docker-images/blob/master/base/10.15.3/Dockerfile), except it uses the `slim` variant of `node:10.15.3` to reduce the uncompressed image size by about 600MB.


### PR DESCRIPTION
This one is around 600MB smaller than the original `cypress-base`. Should help us take up less disk space in CI. 