### PR TITLE
pre-installing cypress itself in the base image

### DIFF
--- a/cypress-base/Dockerfile
+++ b/cypress-base/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
 
 RUN npm install -g npm@6.9.0
 RUN npm install -g yarn@1.15.2
+RUN npm install cypress@3.4.1
 
 # versions of local tools
 RUN echo  " node version:    $(node -v) \n" \

--- a/cypress-base/README.md
+++ b/cypress-base/README.md
@@ -1,3 +1,7 @@
 # Ecosia Cypress Base
 
 This image is almost identical to [`cypress/base:10.15.3`](https://github.com/cypress-io/cypress-docker-images/blob/master/base/10.15.3/Dockerfile), except it uses the `slim` variant of `node:10.15.3` to reduce the uncompressed image size by about 600MB.
+
+## IMPORTANT: Pushing to Docker Hub
+
+If you're pushing a new version of this image, make sure to tag it with the Cypress version it installs, so that images using it as a base can pick the Cypress version they want to use - e.g. `docker tag my_image_id ecosiadev/cypress-base:3.4.1`.


### PR DESCRIPTION
This was actually @DoHe's idea

The official `cypress-base` doesn't want to tell you which `cypress` version to use, so it doesn't actually install the cypress binary, which is *by far* the hugest part of our e2e test images.

This does have the sad side effect of every test image having to download and store cypress by itself. Takes bloody ages and kills CI half the time because it's like, 1 whole gigabyte 😮 

Thing is, if we install the correct version of `cypress` in our custom base image, we can make use of Docker's sharing of readonly layers, meaning that the ~500MB that cypress takes up, is only downloaded and stored once. Yay!!

As things stand this should shave off another ~1.5GB off a full CI build's disk usage.

The only downside is, if we ever want to use a newer `cypress`, we'll have to update the base image first. That's why I'm going to tag subsequent versions of this image with the `cypress` version it installs, e.g. `ecosiadev/cypress-base:3.4.1`. That way individual projects could choose which version to use.

**N.B.** I checked and we're currently only using 3.4.1 so this should be ready to use for all projects