### PR TITLE
Make cypress global

### DIFF
--- a/cypress-base/Dockerfile
+++ b/cypress-base/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 RUN npm install -g npm@6.9.0
 RUN npm install -g yarn@1.15.2
-RUN npm install cypress@3.4.1
+RUN npm install -g cypress@3.4.1
 
 # versions of local tools
 RUN echo  " node version:    $(node -v) \n" \


### PR DESCRIPTION
For this to be easily usable by the inheriting image, this would have to be global too