### PR TITLE
Add cypress-lighthouse image

### DIFF
--- a/cypress-lighthouse/Dockerfile
+++ b/cypress-lighthouse/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:10.15.3-slim
+
+RUN apt-get update && \
+  apt-get install -y \
+  libgtk2.0-0 \
+  libnotify-dev \
+  libgconf-2-4 \
+  libnss3 \
+  libxss1 \
+  libasound2 \
+  xvfb \
+  chromium
+
+RUN npm install -g npm@6.9.0
+RUN npm install -g yarn@1.15.2
+RUN npm install --unsafe-perm=true --allow-root -g cypress@3.4.1
+
+# versions of local tools
+RUN echo  "node version:    $(node -v) \n" \
+  "npm version:     $(npm -v) \n" \
+  "yarn version:    $(yarn -v) \n" \
+  "cypress version: $(cypress -v) \n" \
+  "debian version:  $(cat /etc/debian_version) \n"

--- a/cypress-lighthouse/Makefile
+++ b/cypress-lighthouse/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build push pull
+
+VERSION?=0.1.0
+
+build:
+	docker build -t ecosiadev/cypress-lighthouse:${VERSION} ./
+
+push:
+	docker push ecosiadev/cypress-lighthouse:${VERSION}
+
+latest:
+	docker build -t ecosiadev/cypress-lighthouse:latest ./
+	docker push ecosiadev/cypress-lighthouse:latest
+
+pull:
+	docker pull ecosiadev/cypress-lighthouse:latest

--- a/cypress-lighthouse/README.md
+++ b/cypress-lighthouse/README.md
@@ -1,3 +1,3 @@
 # Ecosia Cypress Base
 
-This image is almost identical to [`ecosiadev/cypress-base:10.15.3`](../cypress-base), except it installs `chromium` for Lighthouse to run it.
+This image is almost identical to [`ecosiadev/cypress-base:10.15.3`](../cypress-base), except it installs `chromium` for Lighthouse to find and run.

--- a/cypress-lighthouse/README.md
+++ b/cypress-lighthouse/README.md
@@ -1,0 +1,3 @@
+# Ecosia Cypress Base
+
+This image is almost identical to [`ecosiadev/cypress-base:10.15.3`](../cypress-base), except it installs `chromium` for Lighthouse to run it.


### PR DESCRIPTION
To run Chrome/Chromium headless, Lighthouse needs it to be installed. This image is very similar to `../cypress-base` and can be used to run Cypress and Lighthouse.