### PR TITLE
Enable experimental docker features in the docker-circleci image

### DIFF
--- a/docker-circleci/Dockerfile
+++ b/docker-circleci/Dockerfile
@@ -17,3 +17,4 @@ RUN apk upgrade && \
 
 RUN pip3 install --user awscli
 ENV PATH="~/.local/bin:${PATH}"
+ENV DOCKER_CLI_EXPERIMENTAL="enabled"


### PR DESCRIPTION
The particular feature I'm looking at is BuildKit, which allows us to do magical things like mount a shared cache directory on specific `RUN` commands.

Using Buildkit, I was able to reduce individual `yarn install` times of frontend projects down to **10-30 seconds** (see https://github.com/ecosia/core/pull/3000)