### PR TITLE
docker-circleci: Installing jq and alphabetical ordering of apk pkgs

### DIFF
--- a/docker-circleci/Dockerfile
+++ b/docker-circleci/Dockerfile
@@ -7,12 +7,13 @@ COPY --from=gobuilder /go/bin/docker-credential-ecr-login /usr/local/bin/docker-
 
 RUN apk upgrade && \
     apk add --update \
-    make \
-    git \
     bash \
+    git \
+    jq \
+    make \
     openssh-client \
-    python3 \
     parallel \
+    python3 \
     sudo
 
 RUN pip3 install --user awscli


### PR DESCRIPTION
I needed jq to do some stuff with `mbt` output in Circle, this allows me to do so without installing it manually :)