### PR TITLE
helmfile docker image used by eks circleci

### DIFF
--- a/helmfile/Dockerfile
+++ b/helmfile/Dockerfile
@@ -1,0 +1,3 @@
+FROM vault:1.3.3 as vault
+FROM chatwork/helmfile:0.111.0
+COPY --from=vault /bin/vault /usr/local/bin/vault

--- a/helmfile/Makefile
+++ b/helmfile/Makefile
@@ -1,0 +1,17 @@
+.PHONY: build push pull
+
+VERSION?=0.111.0
+TAG?=ecosiadev/helmfile
+
+build:
+	docker build -t ${TAG}:${VERSION} ./
+
+push:
+	docker push ${TAG}:${VERSION}
+
+latest:
+	docker build -t ${TAG}:latest ./
+	docker push ${TAG}:latest
+
+pull:
+	docker pull ${TAG}:latest


### PR DESCRIPTION
## Motivation
- use vault and helmfile together to insert static secrets
- current userland helmfile docker image doesn't have vault installed