### PR TITLE
[kubectl-terraform-circleci] bump to Terraform 0.13.5

### DIFF
--- a/kubectl-terraform-circleci/Dockerfile
+++ b/kubectl-terraform-circleci/Dockerfile
@@ -1,11 +1,4 @@
-FROM golang:1.13-alpine as gobuilder
-RUN apk add --update git
-RUN GO111MODULE=on go get -u github.com/russellcardullo/terraform-provider-pingdom
-RUN git clone https://github.com/louy/terraform-provider-uptimerobot && \
-    cd terraform-provider-uptimerobot && \
-    go install
-
-FROM hashicorp/terraform:0.12.25 as tf
+FROM hashicorp/terraform:0.13.5 as tf
 FROM ecosiadev/kubectl:v1.15.12 as kubectl
 FROM ecosiadev/kustomize:v3.5.4 as kustomize
 FROM vault:1.0.3 as vault
@@ -22,21 +15,18 @@ RUN apk add --update \
     bash \
     curl
 
-COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
-COPY --from=kustomize /usr/bin/kustomize /usr/local/bin/kustomize
-COPY --from=helm /usr/bin/helm /usr/local/bin/helm
-COPY --from=vault /bin/vault /usr/local/bin/vault
-COPY --from=tf /bin/terraform /usr/local/bin/terraform
-COPY --from=gobuilder /go/bin/ /tfproviders/
-
 RUN addgroup -S circleci && adduser --shell /bin/bash -S -G circleci circleci
 RUN echo "circleci ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 USER circleci
 WORKDIR /home/circleci
 
-RUN mkdir -p ~/.terraform.d/plugins/linux_amd64 && \
-    sudo mv /tfproviders/* ~/.terraform.d/plugins/linux_amd64/ && sudo chown -R circleci:circleci ~/.terraform.d
-
 ENV PATH "/home/circleci/.local/bin:$PATH"
+
 RUN pip3 install --user awscli && pip install --user pipenv
+
+COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=kustomize /usr/bin/kustomize /usr/local/bin/kustomize
+COPY --from=helm /usr/bin/helm /usr/local/bin/helm
+COPY --from=vault /bin/vault /usr/local/bin/vault
+COPY --from=tf /bin/terraform /usr/local/bin/terraform

--- a/kubectl-terraform-circleci/Makefile
+++ b/kubectl-terraform-circleci/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build push pull
 
-VERSION?=0.8
+VERSION?=0.9
 TAG?=kubectl-terraform-circleci
 
 build:

--- a/kubectl-terraform-circleci/README.md
+++ b/kubectl-terraform-circleci/README.md
@@ -1,2 +1,21 @@
 # kubectl-terraform-circleci
 Used in our CircleCI pipelines for applying the Kubernetes manifests and generating our infrastructure using terraform.
+
+## Changelog
+
+### 0.9
+
+The 0.9 tag includes Terraform 0.13, which has changed the way third-party provider plugins are [discovered and consumed](https://www.terraform.io/upgrade-guides/0-13.html#new-filesystem-layout-for-local-copies-of-providers). As such the explicit inclusion of the uptimerobot and pingdom plugins has been removed from this image.
+
+Required plugins should be defined explicitly in the Terraform manifests they're used in. e.g
+
+```
+terraform {
+  required_providers {
+    uptimerobot = {
+      source = "louy/uptimerobot"
+      version = "0.5.1"
+    }
+  }
+}
+```


### PR DESCRIPTION
 * Remove uptimerobot + pingdom provider plugin installation.
 * Move awscli installation earlier for efficiency.