### PR TITLE
Updating Yarn version in cypress-base

### DIFF
--- a/cypress-base/Dockerfile
+++ b/cypress-base/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
 
 RUN npm install -g npm@6.14.6
 RUN rm /usr/local/bin/yarnpkg /usr/local/bin/yarn
-RUN npm install -g yarn@1.15.2
+RUN npm install -g yarn@1.22.10
 RUN npm install --unsafe-perm=true --allow-root -g cypress@3.4.1
 
 RUN apt-get clean


### PR DESCRIPTION
I forgot we're pegging the Yarn version in the cypress-base dockerfile, need to update it to run on node 14.15