### PR TITLE
helmfile: Bump to 0.135.0 and update sops

### DIFF
--- a/helmfile/Dockerfile
+++ b/helmfile/Dockerfile
@@ -1,8 +1,10 @@
 FROM vault:1.3.3 as vault
 FROM ecosiadev/kubectl:v1.15.12 as kubectl
 FROM alpine/helm:3.1.2 as helm
-FROM chatwork/helmfile:0.128.0
+FROM mozilla/sops:v3.6.1-alpine as sops
+FROM chatwork/helmfile:0.135.0
 
+COPY --from=sops /usr/local/bin/sops /usr/local/bin/sops
 COPY --from=vault /bin/vault /usr/local/bin/vault
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=helm /usr/bin/helm /usr/local/bin/helm

--- a/helmfile/Makefile
+++ b/helmfile/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build push pull
 
-VERSION?=0.128.0
+VERSION?=0.135.0
 TAG?=ecosiadev/helmfile
 
 build:


### PR DESCRIPTION
This is the updated Docker image being referenced in ecosia/platform#337