### PR TITLE
Installing latest stable Google Chrome in the Lighthouse image

### DIFF
--- a/cypress-lighthouse/Dockerfile
+++ b/cypress-lighthouse/Dockerfile
@@ -1,6 +1,11 @@
 FROM ecosiadev/cypress-base:3.7.1
 
 RUN apt-get update && \
-  apt-get install -y chromium
+  apt-get install -y curl
+
+# install latest stable Chrome
+RUN curl -LO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+  apt-get install -y ./google-chrome-stable_current_amd64.deb && \
+  rm google-chrome-stable_current_amd64.deb
 
 RUN apt-get clean

--- a/cypress-lighthouse/Makefile
+++ b/cypress-lighthouse/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build push pull
 
-VERSION?=0.4.2
+VERSION?=1.0.0
 
 build:
 	docker build -t ecosiadev/cypress-lighthouse:${VERSION} ./


### PR DESCRIPTION
Looks like the last available `chromium` version in the Debian repositories is 73, which is really old and newer Lighthouse versions don't support it anymore.

This PR makes it so we use Google Chrome `deb` from the official mirror instead. This should allow us to keep Lighthouse up to date and always test on the latest Chrome version.

Bumping the docker image version to 1.0.0 because of this fundamental change.