### PR TITLE
PLAT-953: upgrade kubectl to v1.17.17

### DIFF
--- a/kubectl-terraform-circleci/Dockerfile
+++ b/kubectl-terraform-circleci/Dockerfile
@@ -1,4 +1,4 @@
-FROM ecosiadev/kubectl:v1.16.15 as kubectl
+FROM ecosiadev/kubectl:v1.17.17 as kubectl
 FROM ecosiadev/kustomize:v3.5.4 as kustomize
 FROM vault:1.0.3 as vault
 FROM alpine/helm:2.13.1 as helm

--- a/kubectl-terraform-circleci/Makefile
+++ b/kubectl-terraform-circleci/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build push pull
 
-VERSION?=0.13
+VERSION?=0.14
 TAG?=kubectl-terraform-circleci
 
 build:

--- a/kubectl/Dockerfile
+++ b/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-ENV KUBECTL_VERSION="v1.16.15"
+ENV KUBECTL_VERSION="v1.17.17"
 
 RUN apk add --no-cache ca-certificates \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/kubectl/Makefile
+++ b/kubectl/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build push pull
 
-VERSION?=v1.16.15
+VERSION?=v1.17.17
 TAG?=ecosiadev/kubectl
 
 build:


### PR DESCRIPTION
After upgrading the clusters to K8s 1.17, this image will be used across the following repositories: https://github.com/search?q=org%3Aecosia+ecosiadev%2Fkubectl-terraform-circleci&type=code